### PR TITLE
Handle JSONL loading for processed knowledge

### DIFF
--- a/backend/services/knowledge_chunking_service.py
+++ b/backend/services/knowledge_chunking_service.py
@@ -540,15 +540,19 @@ QUANTITATIVE METRICS:
             return False
     
     def save_processed_knowledge(self, filepath: str):
-        """Save processed knowledge to file"""
+        """Save processed knowledge to file in JSON Lines (.jsonl) format"""
+        filepath = str(Path(filepath).with_suffix('.jsonl'))
         with open(filepath, 'w', encoding='utf-8') as f:
-            json.dump(self.processed_knowledge, f, indent=2, ensure_ascii=False)
-    
+            json.dump(self.processed_knowledge, f, ensure_ascii=False)
+            f.write('\n')
+
     def load_processed_knowledge(self, filepath: str) -> bool:
-        """Load processed knowledge from file"""
+        """Load processed knowledge from file in JSON Lines (.jsonl) format"""
         try:
+            filepath = str(Path(filepath).with_suffix('.jsonl'))
             with open(filepath, 'r', encoding='utf-8') as f:
-                self.processed_knowledge = json.load(f)
+                first_line = f.readline()
+                self.processed_knowledge = json.loads(first_line) if first_line else {}
             return True
         except Exception as e:
             logger.error(f"Failed to load processed knowledge: {e}")


### PR DESCRIPTION
## Summary
- save processed knowledge in JSONL format
- load only the first JSONL entry to avoid `Extra data` errors

## Testing
- `pytest`
